### PR TITLE
[vscode] Decorations for #file is much better and does not break

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
@@ -26,6 +26,20 @@ import { IChatRequestVariableValue, IChatVariablesService, IDynamicVariable } fr
 
 export const dynamicVariableDecorationType = 'chat-dynamic-variable';
 
+function changeIsBeforeVariable(changeRange: IRange, variableRange: IRange): boolean {
+	return (
+		changeRange.endLineNumber < variableRange.startLineNumber ||
+		(changeRange.endLineNumber === variableRange.startLineNumber && changeRange.endColumn <= variableRange.startColumn)
+	);
+}
+
+function changeIsAfterVariable(changeRange: IRange, variableRange: IRange): boolean {
+	return (
+		changeRange.startLineNumber > variableRange.endLineNumber ||
+		(changeRange.startLineNumber === variableRange.endLineNumber && changeRange.startColumn >= variableRange.endColumn)
+	);
+}
+
 export class ChatDynamicVariableModel extends Disposable implements IChatWidgetContrib {
 	public static readonly ID = 'chatDynamicVariableModel';
 
@@ -60,18 +74,61 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 						}
 						return null;
 					} else if (Range.compareRangesUsingStarts(ref.range, c.range) > 0) {
-						const delta = c.text.length - c.rangeLength;
-						return {
-							...ref,
-							range: {
-								startLineNumber: ref.range.startLineNumber,
-								startColumn: ref.range.startColumn + delta,
-								endLineNumber: ref.range.endLineNumber,
-								endColumn: ref.range.endColumn + delta
-							}
-						};
-					}
+						// Determine if the change is before, after, or overlaps with the variable's range.
+						if (changeIsBeforeVariable(c.range, ref.range)) {
+							// Change is before the variable; adjust the variable's range.
 
+							// Calculate line delta
+							const linesInserted = c.text.split('\n').length - 1;
+							const linesRemoved = c.range.endLineNumber - c.range.startLineNumber;
+							const lineDelta = linesInserted - linesRemoved;
+
+							// Initialize column delta
+							let columnDelta = 0;
+
+							// Check if change is on the same line as the variable's start
+							if (c.range.endLineNumber === ref.range.startLineNumber) {
+								// Change is on the same line
+								if (c.range.endColumn <= ref.range.startColumn) {
+									// Change occurs before the variable's start column
+									if (linesInserted === 0) {
+										// Single-line change
+										const charsInserted = c.text.length;
+										const charsRemoved = c.rangeLength;
+										columnDelta = charsInserted - charsRemoved;
+									} else {
+										// Multi-line change (e.g., newline inserted)
+										// Adjust columns accordingly
+										columnDelta = - (c.range.endColumn - 1);
+										// The variable's column should be adjusted to account for the reset after newline
+									}
+								} else {
+									// Change occurs after the variable's start column
+									// Variable is unaffected
+									columnDelta = 0;
+								}
+							} else if (c.range.endLineNumber < ref.range.startLineNumber) {
+								// Change is on lines before the variable's line
+								columnDelta = 0;
+							}
+
+							return {
+								...ref,
+								range: {
+									startLineNumber: ref.range.startLineNumber + lineDelta,
+									startColumn: ref.range.startColumn + columnDelta,
+									endLineNumber: ref.range.endLineNumber + lineDelta,
+									endColumn: ref.range.endColumn + columnDelta
+								}
+							};
+						} else if (changeIsAfterVariable(c.range, ref.range)) {
+							// Change is after the variable; no adjustment needed.
+							return ref;
+						} else {
+							// Change overlaps with the variable; the variable is broken.
+							return null;
+						}
+					}
 					return ref;
 				}));
 			});


### PR DESCRIPTION
The current implementation of the range detection is broken, especially for the case where the ranges are compared using the strats.

If we insert a new line before the #file symbol, the range is not updated properly (note previously we were just updating the column)

After this change, we can freely insert new lines anywhere and the ranges get updated. This required a bit of work on doing the range calculation properly, but helps with the user experience.

Before:

https://github.com/user-attachments/assets/92c43c65-188e-4916-aa04-dc94dfa7f999

After:


https://github.com/user-attachments/assets/1d096635-56b4-40ac-98da-8890d370c17f


I have tested these changes since I am working on a fork of vscode, but the behavior and the code is the same which copilot chat uses and noticed that copilot chat also breaks for the behavior which I am fixing right now.

To test:
- start vscode in debug mode
- have copilot chat installed
- try using #file and then insert new line before and watch how it retains the decorations now

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
